### PR TITLE
Fix maximum extended level check in load_amd_features()

### DIFF
--- a/libcpuid/recog_amd.c
+++ b/libcpuid/recog_amd.c
@@ -307,7 +307,7 @@ static void load_amd_features(struct cpu_raw_data_t* raw, struct cpu_id_t* data)
 		match_features(matchtable_edx81, COUNT_OF(matchtable_edx81), raw->ext_cpuid[1][3], data);
 		match_features(matchtable_ecx81, COUNT_OF(matchtable_ecx81), raw->ext_cpuid[1][2], data);
 	}
-	if (raw->ext_cpuid[0][0] >= 0x80000001)
+	if (raw->ext_cpuid[0][0] >= 0x80000007)
 		match_features(matchtable_edx87, COUNT_OF(matchtable_edx87), raw->ext_cpuid[7][3], data);
 	if (raw->ext_cpuid[0][0] >= 0x8000001a) {
 		/* We have the extended info about SSE unit size */


### PR DESCRIPTION
In libcpuid/recog_amd.c in load_amd_features() the maximum extended level check compares against the wrong value (0x80000001 vs 0x80000007).