### PR TITLE
MSVC warning fix

### DIFF
--- a/libcpuid/libcpuid_util.c
+++ b/libcpuid/libcpuid_util.c
@@ -129,7 +129,7 @@ void generic_get_cpu_list(const struct match_entry_t* matchtable, int count,
 				break;
 			}
 		if (!good) continue;
-#ifdef _MSC_VER
+#if defined(_MSC_VER)
 		list->names[n++] = _strdup(matchtable[i].name);
 #else
 		list->names[n++] = strdup(matchtable[i].name);

--- a/libcpuid/libcpuid_util.c
+++ b/libcpuid/libcpuid_util.c
@@ -129,7 +129,11 @@ void generic_get_cpu_list(const struct match_entry_t* matchtable, int count,
 				break;
 			}
 		if (!good) continue;
+#ifdef _MSC_VER
+		list->names[n++] = _strdup(matchtable[i].name);
+#else
 		list->names[n++] = strdup(matchtable[i].name);
+#endif
 	}
 	list->num_entries = n;
 }


### PR DESCRIPTION
Using _strdup instead of strdup if using Visual C++