### PR TITLE
Fix X2APIC, AES, XSAVE and OSXSAVE feature detection on AMD processors

### DIFF
--- a/libcpuid/cpuid_main.c
+++ b/libcpuid/cpuid_main.c
@@ -187,8 +187,10 @@ static void load_features_common(struct cpu_raw_data_t* raw, struct cpu_id_t* da
 		{ 12, CPU_FEATURE_FMA3 },
 		{ 13, CPU_FEATURE_CX16 },
 		{ 19, CPU_FEATURE_SSE4_1 },
-		{ 21, CPU_FEATURE_X2APIC },
 		{ 23, CPU_FEATURE_POPCNT },
+		{ 25, CPU_FEATURE_AES },
+		{ 26, CPU_FEATURE_XSAVE },
+		{ 27, CPU_FEATURE_OSXSAVE },
 		{ 28, CPU_FEATURE_AVX },
 		{ 29, CPU_FEATURE_F16C },
 	};

--- a/libcpuid/recog_intel.c
+++ b/libcpuid/recog_intel.c
@@ -389,10 +389,8 @@ static void load_intel_features(struct cpu_raw_data_t* raw, struct cpu_id_t* dat
 		{ 15, CPU_FEATURE_PDCM },
 		{ 18, CPU_FEATURE_DCA },
 		{ 20, CPU_FEATURE_SSE4_2 },
+		{ 21, CPU_FEATURE_X2APIC },
 		{ 22, CPU_FEATURE_MOVBE },
-		{ 25, CPU_FEATURE_AES },
-		{ 26, CPU_FEATURE_XSAVE },
-		{ 27, CPU_FEATURE_OSXSAVE },
 		{ 30, CPU_FEATURE_RDRAND },
 	};
 	const struct feature_map_t matchtable_edx81[] = {

--- a/tests/amd/bulldozer/bulldozer-x4.test
+++ b/tests/amd/bulldozer/bulldozer-x4.test
@@ -90,4 +90,4 @@ intel_fn11[3]=00000000 00000000 00000000 00000000
 64
 128 (authoritative)
 Bulldozer X4
-fpu vme de pse tsc msr pae mce cx8 apic mtrr sep pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht pni monitor ssse3 cx16 sse4_1 syscall popcnt avx mmxext nx fxsr_opt rdtscp lm lahf_lm cmp_legacy svm abm misalignsse sse4a 3dnowprefetch osvw ibs skinit wdt ts ttp tm_amd 100mhzsteps hwpstate constant_tsc xop fma4 cpb
+fpu vme de pse tsc msr pae mce cx8 apic mtrr sep pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht pni monitor ssse3 cx16 sse4_1 syscall popcnt aes xsave osxsave avx mmxext nx fxsr_opt rdtscp lm lahf_lm cmp_legacy svm abm misalignsse sse4a 3dnowprefetch osvw ibs skinit wdt ts ttp tm_amd 100mhzsteps hwpstate constant_tsc xop fma4 cpb

--- a/tests/amd/bulldozer/vishera-x4.test
+++ b/tests/amd/bulldozer/vishera-x4.test
@@ -90,4 +90,4 @@ intel_fn11[3]=00000000 00000000 00000000 00000000
 64
 128 (authoritative)
 Vishera X4
-fpu vme de pse tsc msr pae mce cx8 apic mtrr sep pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht pni monitor ssse3 cx16 sse4_1 syscall popcnt avx mmxext nx fxsr_opt rdtscp lm lahf_lm cmp_legacy svm abm misalignsse sse4a 3dnowprefetch osvw ibs skinit wdt ts ttp tm_amd 100mhzsteps hwpstate constant_tsc xop fma3 fma4 f16c cpb aperfmperf bmi1
+fpu vme de pse tsc msr pae mce cx8 apic mtrr sep pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht pni monitor ssse3 cx16 sse4_1 syscall popcnt aes xsave osxsave avx mmxext nx fxsr_opt rdtscp lm lahf_lm cmp_legacy svm abm misalignsse sse4a 3dnowprefetch osvw ibs skinit wdt ts ttp tm_amd 100mhzsteps hwpstate constant_tsc xop fma3 fma4 f16c cpb aperfmperf bmi1


### PR DESCRIPTION
X2APIC is Intel only, and AES, XSAVE and OSXSAVE are common to both AMD and Intel.

References:
[Pg. 11 CPUID Fn0000_0001_ECX Feature Identifiers](http://support.amd.com/TechDocs/25481.pdf)