### PR TITLE
Expose 'brand code' and 'model code'

### DIFF
--- a/cpuid_tool/cpuid_tool.c
+++ b/cpuid_tool/cpuid_tool.c
@@ -86,6 +86,8 @@ typedef enum {
 	NEED_CLOCK_IC,
 	NEED_RDMSR,
 	NEED_SSE_UNIT_SIZE,
+	NEED_BRAND_CODE, //intel
+	NEED_MODEL_CODE, //intel
 } output_data_switch;
 
 int need_input = 0,
@@ -98,7 +100,7 @@ int need_input = 0,
     need_version = 0,
     need_cpulist = 0;
 
-#define MAX_REQUESTS 32
+#define MAX_REQUESTS 34
 int num_requests = 0;
 output_data_switch requests[MAX_REQUESTS];
 
@@ -138,6 +140,8 @@ matchtable[] = {
 	{ NEED_CLOCK_IC     , "--clock-ic"     , 1},
 	{ NEED_RDMSR        , "--rdmsr"        , 0},
 	{ NEED_SSE_UNIT_SIZE, "--sse-size"     , 1},
+	{ NEED_BRAND_CODE   , "--brandcode"    , 1},
+	{ NEED_MODEL_CODE   , "--modelcode"    , 1},
 };
 
 const int sz_match = (sizeof(matchtable) / sizeof(matchtable[0]));
@@ -177,6 +181,7 @@ static void usage(void)
 		}
 	}
 	printf("\n\n");
+	printf("--brandcode and --modelcode have meaning for intel cpus\n\n");
 	printf("If `-' is used for <file>, then stdin/stdout will be used instead of files.\n");
 	printf("When no options are present, the program behaves as if it was invoked with\n");
 	printf("  cpuid_tool \"--save=raw.txt --outfile=report.txt --report --verbose\"\n");
@@ -442,6 +447,12 @@ static void print_info(output_data_switch query, struct cpu_raw_data_t* raw,
 				data->detection_hints[CPU_HINT_SSE_SIZE_AUTH] ? "authoritative" : "non-authoritative");
 			break;
 		}
+		case NEED_BRAND_CODE:
+			fprintf(fout, "%d\n", data->detection_hints[CPU_HINT_BRAND_CODE]);
+			break;
+		case NEED_MODEL_CODE:
+			fprintf(fout, "%d\n", data->detection_hints[CPU_HINT_MODEL_CODE]);
+			break;
 		default:
 			fprintf(fout, "How did you get here?!?\n");
 			break;

--- a/libcpuid/libcpuid.h
+++ b/libcpuid/libcpuid.h
@@ -372,6 +372,8 @@ typedef enum {
  */
 typedef enum {
 	CPU_HINT_SSE_SIZE_AUTH = 0,	/*!< SSE unit size is authoritative (not only a Family/Model guesswork, but based on an actual CPUID bit) */
+	CPU_HINT_BRAND_CODE,	/*!< Extra info, ex: set for intel processors */
+	CPU_HINT_MODEL_CODE,	/*!< Extra info, ex: set for intel processors */
 	/* termination */
 	NUM_CPU_HINTS,
 } cpu_hint_t;

--- a/libcpuid/recog_intel.c
+++ b/libcpuid/recog_intel.c
@@ -803,9 +803,12 @@ int cpuid_identify_intel(struct cpu_raw_data_t* raw, struct cpu_id_t* data)
 	} else if (raw->basic_cpuid[0][0] >= 2) {
 		decode_intel_oldstyle_cache_info(raw, data);
 	}
+	data->detection_hints[CPU_HINT_BRAND_CODE] = get_brand_code(data);
+	data->detection_hints[CPU_HINT_MODEL_CODE] = get_model_code(data);
 	decode_intel_number_of_cores(raw, data);
 	match_cpu_codename(cpudb_intel, COUNT_OF(cpudb_intel), data,
-		get_brand_code(data), get_model_code(data));
+		data->detection_hints[CPU_HINT_BRAND_CODE],
+		data->detection_hints[CPU_HINT_MODEL_CODE]);
 	return 0;
 }
 


### PR DESCRIPTION
These values are used internally in recog_intel.c

However these values are useful for external apps
to create their own search criteria, so it's a good idea to expose
them somehow, in this case the values are stored in
data->detection_hints[1|2]

cpuid_tool can display these values with:
--brandcode
--modelcode