### PR TITLE
Changes for MSR

### DIFF
--- a/libcpuid/cpuid_main.c
+++ b/libcpuid/cpuid_main.c
@@ -635,6 +635,7 @@ const char* cpuid_error(void)
 		{ ERR_INVMSR   , "Invalid MSR"},
 		{ ERR_INVCNB   , "Invalid core number"},
 		{ ERR_HANDLE_R , "Error on handle read"},
+		{ ERR_INVRANGE , "Invalid given range"},
 	};
 	unsigned i;
 	for (i = 0; i < COUNT_OF(matchtable); i++)

--- a/libcpuid/exports.def
+++ b/libcpuid/exports.def
@@ -30,3 +30,5 @@ cpu_clock_by_ic @26
 cpuid_get_total_cpus @27
 cpu_msr_driver_open_core @28
 cpuid_get_vendor @29
+cpu_rdmsr_range @30
+get_bits_value @31

--- a/libcpuid/exports.def
+++ b/libcpuid/exports.def
@@ -31,4 +31,3 @@ cpuid_get_total_cpus @27
 cpu_msr_driver_open_core @28
 cpuid_get_vendor @29
 cpu_rdmsr_range @30
-get_bits_value @31

--- a/libcpuid/libcpuid.h
+++ b/libcpuid/libcpuid.h
@@ -832,7 +832,7 @@ struct msr_driver_t* cpu_msr_driver_open(void);
  *          The error message can be obtained by calling \ref cpuid_error.
  *          @see cpu_error_t
  */
-struct msr_driver_t* cpu_msr_driver_open_core(uint8_t core_num);
+struct msr_driver_t* cpu_msr_driver_open_core(unsigned core_num);
 
 /**
  * @brief Reads a Model-Specific Register (MSR)

--- a/libcpuid/libcpuid.h
+++ b/libcpuid/libcpuid.h
@@ -396,6 +396,7 @@ typedef enum {
 	ERR_INVMSR   = -13,     /*!< "Invalid MSR" */
 	ERR_INVCNB   = -14,     /*!< "Invalid core number" */
 	ERR_HANDLE_R = -15,     /*!< "Error on handle read" */
+	ERR_INVRANGE = -16,     /*!< "Invalid given range" */
 } cpu_error_t;
 
 /**

--- a/libcpuid/libcpuid.h
+++ b/libcpuid/libcpuid.h
@@ -885,8 +885,6 @@ typedef enum {
 /**
  * @brief Similar to \ref cpu_rdmsr, but extract a range of bits
  *
- * It is similar to use \ref cpu_rdmsr then \ref get_bits_value.
- *
  * @param handle - a handle to the MSR reader driver, as created by
  *                 cpu_msr_driver_open
  * @param msr_index - the numeric ID of the MSR you want to read
@@ -900,17 +898,6 @@ typedef enum {
  */
 int cpu_rdmsr_range(struct msr_driver_t* handle, uint32_t msr_index, uint8_t highbit,
                     uint8_t lowbit, uint64_t* result);
-
-/**
- * @brief Extract a range of bits from MSR value
- *
- * @param val - a 64-bit integer, where the MSR value is stored
- * @param highbit - the high bit in range, must be inferior to 64
- * @param lowbit - the low bit in range, must be equal or superior to 0
- *
- * @returns bits between highbit and lowbit
- */
-uint64_t get_bits_value(uint64_t val, int highbit, int lowbit);
 
 /**
  * @brief Reads extended CPU information from Model-Specific Registers.

--- a/libcpuid/libcpuid.h
+++ b/libcpuid/libcpuid.h
@@ -883,6 +883,36 @@ typedef enum {
 } cpu_msrinfo_request_t;
 
 /**
+ * @brief Similar to \ref cpu_rdmsr, but extract a range of bits
+ *
+ * It is similar to use \ref cpu_rdmsr then \ref get_bits_value.
+ *
+ * @param handle - a handle to the MSR reader driver, as created by
+ *                 cpu_msr_driver_open
+ * @param msr_index - the numeric ID of the MSR you want to read
+ * @param highbit - the high bit in range, must be inferior to 64
+ * @param lowbit - the low bit in range, must be equal or superior to 0
+ * @param result - a pointer to a 64-bit integer, where the MSR value is stored
+ *
+ * @returns zero if successful, and some negative number on error.
+ *          The error message can be obtained by calling \ref cpuid_error.
+ *          @see cpu_error_t
+ */
+int cpu_rdmsr_range(struct msr_driver_t* handle, uint32_t msr_index, uint8_t highbit,
+                    uint8_t lowbit, uint64_t* result);
+
+/**
+ * @brief Extract a range of bits from MSR value
+ *
+ * @param val - a 64-bit integer, where the MSR value is stored
+ * @param highbit - the high bit in range, must be inferior to 64
+ * @param lowbit - the low bit in range, must be equal or superior to 0
+ *
+ * @returns bits between highbit and lowbit
+ */
+uint64_t get_bits_value(uint64_t val, int highbit, int lowbit);
+
+/**
  * @brief Reads extended CPU information from Model-Specific Registers.
  * @param handle - a handle to an open MSR driver, @see cpu_msr_driver_open
  * @param which - which info field should be returned. A list of

--- a/libcpuid/libcpuid.h
+++ b/libcpuid/libcpuid.h
@@ -822,7 +822,7 @@ struct msr_driver_t* cpu_msr_driver_open(void);
 /**
  * @brief Similar to \ref cpu_msr_driver_open, but accept one parameter
  *
- * This function works on Linux only
+ * This function works on certain operating system (GNU/Linux, FreeBSD)
  *
  * @param core_num specify the core number for MSR.
  *          The first core number is 0.
@@ -832,7 +832,7 @@ struct msr_driver_t* cpu_msr_driver_open(void);
  *          The error message can be obtained by calling \ref cpuid_error.
  *          @see cpu_error_t
  */
-struct msr_driver_t* cpu_msr_driver_open_core(int core_num);
+struct msr_driver_t* cpu_msr_driver_open_core(uint8_t core_num);
 
 /**
  * @brief Reads a Model-Specific Register (MSR)

--- a/libcpuid/libcpuid.sym
+++ b/libcpuid/libcpuid.sym
@@ -27,3 +27,5 @@ cpu_clock_by_ic
 cpuid_get_total_cpus
 cpu_msr_driver_open_core
 cpuid_get_vendor
+cpu_rdmsr_range
+get_bits_value

--- a/libcpuid/libcpuid.sym
+++ b/libcpuid/libcpuid.sym
@@ -28,4 +28,3 @@ cpuid_get_total_cpus
 cpu_msr_driver_open_core
 cpuid_get_vendor
 cpu_rdmsr_range
-get_bits_value

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -420,7 +420,20 @@ static int perfmsr_measure(struct msr_driver_t* handle, int msr)
 #define MSR_PSTATE_S 0xC0010063
 #define MSR_PSTATE_0 0xC0010064
 
-static uint64_t get_bits_value(uint64_t val, int highbit, int lowbit)
+int cpu_rdmsr_range(struct msr_driver_t* handle, uint32_t msr_index, uint8_t highbit,
+                    uint8_t lowbit, uint64_t* result)
+{
+	if(highbit > 63 || lowbit > highbit)
+		return set_error(ERR_INVRANGE);
+
+	if(cpu_rdmsr(handle, msr_index, result))
+		return set_error(ERR_HANDLE_R);
+
+	*result = get_bits_value(*result, highbit, lowbit);
+	return 0;
+}
+
+uint64_t get_bits_value(uint64_t val, int highbit, int lowbit)
 {
 	uint64_t data = val;
 	const uint8_t bits = highbit - lowbit + 1;
@@ -432,19 +445,6 @@ static uint64_t get_bits_value(uint64_t val, int highbit, int lowbit)
 	}
 
 	return data;
-}
-
-static int cpu_rdmsr_range(struct msr_driver_t* handle, uint32_t msr_index, uint8_t highbit,
-                    uint8_t lowbit, uint64_t* result)
-{
-	if(highbit > 63 || lowbit > highbit)
-		return set_error(ERR_INVRANGE);
-
-	if(cpu_rdmsr(handle, msr_index, result))
-		return set_error(ERR_HANDLE_R);
-
-	*result = get_bits_value(*result, highbit, lowbit);
-	return 0;
 }
 
 int cpu_msrinfo(struct msr_driver_t* handle, cpu_msrinfo_request_t which)

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -569,12 +569,12 @@ int cpu_msrinfo(struct msr_driver_t* handle, cpu_msrinfo_request_t which)
 		{
 			if(cpuid_get_vendor() == VENDOR_INTEL)
 			{
-				if(!multiplier)
+				if(!multiplier) {
 					cpu_rdmsr_range(handle, PLATFORM_INFO_MSR, PLATFORM_INFO_MSR_high, PLATFORM_INFO_MSR_low, &val);
-				if(val > 0) {
 					multiplier = (int) val;
-					return multiplier * 100;
 				}
+				if(multiplier > 0)
+					return multiplier * 100;
 			}
 			err = cpu_rdmsr(handle, 0x198, &r);
 			if (err) return CPU_INVALID_VALUE;
@@ -613,7 +613,7 @@ int cpu_msrinfo(struct msr_driver_t* handle, cpu_msrinfo_request_t which)
 				   MSRC001_00[6B:64][15:9] = CpuVid */
 				uint64_t CpuVid;
 				cpu_rdmsr_range(handle, MSR_PSTATE_S, 2, 0, &val);
-				if(0 <= val && val <= 7) { // Support 8 P-states
+				if(val <= 7) { // Support 8 P-states
 					cpu_rdmsr_range(handle, MSR_PSTATE_0 + val, 15, 9, &CpuVid);
 					return (int) (1.550 - 0.0125 * CpuVid) * 100; // 2.4.1.6.3 - Serial VID (SVI) Encodings
 				}

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -46,12 +46,11 @@ struct msr_driver_t* cpu_msr_driver_open(void)
 	return cpu_msr_driver_open_core(0);
 }
 
-struct msr_driver_t* cpu_msr_driver_open_core(int core_num)
+struct msr_driver_t* cpu_msr_driver_open_core(uint8_t core_num)
 {
 	char msr[32];
 	struct msr_driver_t* handle;
-	if(core_num < 0 && cpuid_get_total_cpus() <= core_num)
-	{
+	if (core_num >= cpuid_get_total_cpus())	{
 		set_error(ERR_INVCNB);
 		return NULL;
 	}
@@ -112,12 +111,11 @@ struct msr_driver_t* cpu_msr_driver_open(void)
 	return cpu_msr_driver_open_core(0);
 }
 
-struct msr_driver_t* cpu_msr_driver_open_core(int core_num)
+struct msr_driver_t* cpu_msr_driver_open_core(uint8_t core_num)
 {
 	char msr[32];
 	struct msr_driver_t* handle;
-	if(core_num < 0 && cpuid_get_total_cpus() <= core_num)
-	{
+	if (core_num >= cpuid_get_total_cpus()) {
 		set_error(ERR_INVCNB);
 		return NULL;
 	}

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -46,7 +46,7 @@ struct msr_driver_t* cpu_msr_driver_open(void)
 	return cpu_msr_driver_open_core(0);
 }
 
-struct msr_driver_t* cpu_msr_driver_open_core(uint8_t core_num)
+struct msr_driver_t* cpu_msr_driver_open_core(unsigned core_num)
 {
 	char msr[32];
 	struct msr_driver_t* handle;
@@ -58,7 +58,7 @@ struct msr_driver_t* cpu_msr_driver_open_core(uint8_t core_num)
 		set_error(ERR_NO_RDMSR);
 		return NULL;
 	}
-	sprintf(msr, "/dev/cpu/%i/msr", core_num);
+	sprintf(msr, "/dev/cpu/%u/msr", core_num);
 	int fd = open(msr, O_RDONLY);
 	if (fd < 0) {
 		if (errno == EIO) {
@@ -111,7 +111,7 @@ struct msr_driver_t* cpu_msr_driver_open(void)
 	return cpu_msr_driver_open_core(0);
 }
 
-struct msr_driver_t* cpu_msr_driver_open_core(uint8_t core_num)
+struct msr_driver_t* cpu_msr_driver_open_core(unsigned core_num)
 {
 	char msr[32];
 	struct msr_driver_t* handle;
@@ -123,7 +123,7 @@ struct msr_driver_t* cpu_msr_driver_open_core(uint8_t core_num)
 		set_error(ERR_NO_RDMSR);
 		return NULL;
 	}
-	sprintf(msr, "/dev/cpuctl%i", core_num);
+	sprintf(msr, "/dev/cpuctl%u", core_num);
 	int fd = open(msr, O_RDONLY);
 	if (fd < 0) {
 		if (errno == EIO) {
@@ -220,7 +220,7 @@ struct msr_driver_t* cpu_msr_driver_open(void)
 	return drv;
 }
 
-struct msr_driver_t* cpu_msr_driver_open_core(int core_num)
+struct msr_driver_t* cpu_msr_driver_open_core(unsigned core_num)
 {
 	warnf("cpu_msr_driver_open_core(): parameter ignored (function is the same as cpu_msr_driver_open)\n");
 	return cpu_msr_driver_open();
@@ -433,7 +433,7 @@ struct msr_driver_t* cpu_msr_driver_open(void)
 	return NULL;
 }
 
-struct msr_driver_t* cpu_msr_driver_open_core(int core_num)
+struct msr_driver_t* cpu_msr_driver_open_core(unsigned core_num)
 {
 	set_error(ERR_NOT_IMP);
 	return NULL;

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -420,35 +420,30 @@ static int perfmsr_measure(struct msr_driver_t* handle, int msr)
 #define MSR_PSTATE_S 0xC0010063
 #define MSR_PSTATE_0 0xC0010064
 
-static int get_bits_value(uint64_t val, int highbit, int lowbit)
+static uint64_t get_bits_value(uint64_t val, int highbit, int lowbit)
 {
 	uint64_t data = val;
-	int bits = highbit - lowbit + 1;
-	if(bits < 64){
-	    data >>= lowbit;
-	    data &= (1ULL<<bits) - 1;
+	const uint8_t bits = highbit - lowbit + 1;
+
+	if(bits < 64) {
+		/* Show only part of register */
+		data >>= lowbit;
+		data &= (1ULL << bits) - 1;
 	}
-	return (int) data;
+
+	return data;
 }
 
 static int cpu_rdmsr_range(struct msr_driver_t* handle, uint32_t msr_index, uint8_t highbit,
                     uint8_t lowbit, uint64_t* result)
 {
-	const uint8_t bits = highbit - lowbit + 1;
-
 	if(highbit > 63 || lowbit > highbit)
 		return set_error(ERR_INVRANGE);
 
 	if(cpu_rdmsr(handle, msr_index, result))
 		return set_error(ERR_HANDLE_R);
 
-	if(bits < 64)
-	{
-		/* Show only part of register */
-		*result >>= lowbit;
-		*result &= (1ULL << bits) - 1;
-	}
-
+	*result = get_bits_value(*result, highbit, lowbit);
 	return 0;
 }
 

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -509,7 +509,7 @@ int cpu_rdmsr_range(struct msr_driver_t* handle, uint32_t msr_index, uint8_t hig
 	if(cpu_rdmsr(handle, msr_index, result))
 		return set_error(ERR_HANDLE_R);
 
-	if(bits < 64 && highbit < 64 && lowbit < highbit) {
+	if(bits < 64) {
 		/* Show only part of register */
 		*result >>= lowbit;
 		*result &= (1ULL << bits) - 1;

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -438,7 +438,7 @@ uint64_t get_bits_value(uint64_t val, int highbit, int lowbit)
 	uint64_t data = val;
 	const uint8_t bits = highbit - lowbit + 1;
 
-	if(bits < 64) {
+	if(bits < 64 && highbit < 64 && lowbit < highbit) {
 		/* Show only part of register */
 		data >>= lowbit;
 		data &= (1ULL << bits) - 1;


### PR DESCRIPTION
There is some changes for MSR code:

- Report for CPU voltage with AMD 10h+ CPUs in `cpu_msrinfo()` 
This is based on your tests.

- A lot of changes for `cpu_rdmsr_range()`, this function look like `cpu_rdmsr()` now
It uses `get_bits_value()`, instead of repeating code.
I have exported these two functions.

- I have redesigned OS-specific code in rdmsr.c: it would be easier to support a new OS
FreeBSD (and DragonFlyBSD) are now supported.

- And some fixes...

I'll do some cleanups in `cpu_msrinfo()` later.