### PR TITLE
Fix & Athlon 64 FX X2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 *.lo
 *.la
 *.o
@@ -26,5 +27,6 @@ install-sh
 libcpuid.pc
 libcpuid/docs
 libcpuid/Doxyfile
+libcpuid/doxyfile.stamp
 ar-lib
 compile

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -616,7 +616,7 @@ static double get_info_min_multiplier(struct msr_driver_t* handle, struct cpu_id
 		if (!err) return reg;
 	}
 
-	return CPU_INVALID_VALUE;
+	return (double) CPU_INVALID_VALUE / 100;
 }
 
 static double get_info_cur_multiplier(struct msr_driver_t* handle, struct cpu_id_t *id,
@@ -645,7 +645,7 @@ static double get_info_cur_multiplier(struct msr_driver_t* handle, struct cpu_id
 		if (!err) return reg;
 	}
 
-	return CPU_INVALID_VALUE;
+	return (double) CPU_INVALID_VALUE / 100;
 }
 
 static double get_info_max_multiplier(struct msr_driver_t* handle, struct cpu_id_t *id,
@@ -685,7 +685,7 @@ static double get_info_max_multiplier(struct msr_driver_t* handle, struct cpu_id
 		if (!err) return reg;
 	}
 
-	return CPU_INVALID_VALUE;
+	return (double) CPU_INVALID_VALUE / 100;
 }
 
 static int get_info_temperature(struct msr_driver_t* handle, struct cpu_id_t *id,
@@ -740,7 +740,7 @@ static double get_info_voltage(struct msr_driver_t* handle, struct cpu_id_t *id,
 		if (!err && MSR_PSTATE_0 + reg <= MSR_PSTATE_7) return 1.550 - 0.0125 * CpuVid;
 	}
 
-	return CPU_INVALID_VALUE;
+	return (double) CPU_INVALID_VALUE / 100;
 }
 
 static double get_info_bus_clock(struct msr_driver_t* handle, struct cpu_id_t *id,
@@ -775,7 +775,7 @@ static double get_info_bus_clock(struct msr_driver_t* handle, struct cpu_id_t *i
 		if (!err) return (double) clock / reg;
 	}
 
-	return CPU_INVALID_VALUE;
+	return (double) CPU_INVALID_VALUE / 100;
 }
 
 int cpu_rdmsr_range(struct msr_driver_t* handle, uint32_t msr_index, uint8_t highbit,

--- a/libcpuid/recog_amd.c
+++ b/libcpuid/recog_amd.c
@@ -115,6 +115,7 @@ const struct match_entry_t cpudb_amd[] = {
 	{ 15, -1, -1, 15,   -1,   1,  1024,    -1, ATHLON_64               ,     0, "Athlon 64 (1024K)"             },
 	{ 15, -1, -1, 15,   -1,   1,    -1,    -1, ATHLON_FX               ,     0, "Athlon FX"                     },
 	{ 15, -1, -1, 15,   -1,   1,    -1,    -1, ATHLON_64_FX            ,     0, "Athlon 64 FX"                  },
+	{ 15,  3, -1, 15,   35,   2,    -1,    -1, ATHLON_64_FX            ,     0, "Athlon 64 FX X2 (Toledo)"      },
 	{ 15, -1, -1, 15,   -1,   2,   512,    -1, ATHLON_64_X2            ,     0, "Athlon 64 X2 (512K)"           },
 	{ 15, -1, -1, 15,   -1,   2,  1024,    -1, ATHLON_64_X2            ,     0, "Athlon 64 X2 (1024K)"          },
 	{ 15, -1, -1, 15,   -1,   1,   512,    -1, TURION_64               ,     0, "Turion 64 (512K)"              },


### PR DESCRIPTION
Reported on X0rg/CPU-X#28, `AMD Athlon(tm) 64 FX-60 Dual Core Processor` is not detected by libcpuid.

Since dbf9991553b603f3b2789a3cf7457a546d9d48d4, `CPU_INVALID_VALUE` is not matched in code like that:
```
int info, val;
info = cpu_msrinfo(handle, which);
if(info != CPU_INVALID_VALUE)
	val = info / 100;
	//Do something with val
```
This pull-request fix this issue.