### PR TITLE
Minor fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -11,7 +11,7 @@ libcpuid (0.3.0) unstable; urgency=low
 
  -- eloaders <eloaders@linux.pl>  Mon, 22 Aug 2016 17:45:21 +0200
 
-libcpuid (0.21) unstable; urgency=low
+libcpuid (0.2.1) unstable; urgency=low
 
   * Initial release add debian directory for libcpuid.
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: libcpuid
 Section: utils
 Priority: optional
 Maintainer: Zhang, Guodong <gdzhang@linx-info.com>
-Build-Depends: debhelper (>= 9), autotools-dev, libtool, automake, autoconf, python
+Build-Depends: debhelper (>= 9), autotools-dev, libtool, automake, autoconf, python, doxygen
 Standards-Version: 3.9.5
 Homepage: https://github.com/anrieff/libcpuid
 

--- a/debian/cpuidtool.install
+++ b/debian/cpuidtool.install
@@ -1,1 +1,2 @@
 ./usr/bin/cpuid_tool
+/usr/share/man/man3/cpuid_tool.3

--- a/debian/libcpuid13-dev.install
+++ b/debian/libcpuid13-dev.install
@@ -3,4 +3,8 @@
 /usr/lib/*/lib*.la
 /usr/lib/*/pkgconfig/
 /usr/include/
-
+/usr/share/man/man3/cpu_id_t.3
+/usr/share/man/man3/cpu_list_t.3
+/usr/share/man/man3/cpu_mark_t.3
+/usr/share/man/man3/cpu_raw_data_t.3
+/usr/share/man/man3/libcpuid.3

--- a/libcpuid/cpuid_main.c
+++ b/libcpuid/cpuid_main.c
@@ -126,6 +126,7 @@ static int get_total_cpus(void)
 #endif
 
 #if defined __FreeBSD__ || defined __OpenBSD__ || defined __NetBSD__ || defined __bsdi__ || defined __QNX__
+#include <sys/types.h>
 #include <sys/sysctl.h>
 
 static int get_total_cpus(void)


### PR DESCRIPTION
Hi,

* On GhostBSD 10.3, I've got the following fatal error:
```
In file included from cpuid_main.c:129:0:
/usr/include/sys/sysctl.h:804:25: error: unknown type name 'u_int'
 int sysctl(const int *, u_int, void *, size_t *, const void *, size_t);
                         ^
cpuid_main.c: In function 'get_total_cpus':
cpuid_main.c:136:2: warning: implicit declaration of function 'sysctl' [-Wimplicit-function-declaration]
  if (sysctl(mib, 2, &ncpus, &len, (void *) 0, 0) != 0) return 1;
  ^
*** [cpuid_main.lo] Error code 1
```
4b4b49b fix that.

* The second patch is about that:
```
[  156s] dpkg-genchanges: warning: the current version (0.3.0) is earlier than the previous one (0.21)
```
Man-pages were missing in Debian package, af35c0a add them.