### PR TITLE
Fix #72

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/anrieff/libcpuid
 Package: libcpuid14
 Architecture: amd64 i386
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${misc:Pre-Depends}
-Replaces: libcpuid11
+Replaces: libcpuid11, libcpuid13
 Description: small C library for x86/x86_64 CPU detection and feature extraction
  For details about the programming API, please see the docs
  on the project's site (http://libcpuid.sourceforge.net/)
@@ -18,7 +18,7 @@ Package: libcpuid14-dev
 Architecture: amd64 i386
 Section: libdevel
 Depends: ${misc:Depends}
-Replaces: libcpuid11-dev
+Replaces: libcpuid11-dev, libcpuid13-dev
 Description: Development files for libcpuid
  For details about the programming API, please see the docs
  on the project's site (http://libcpuid.sourceforge.net/)


### PR DESCRIPTION
let libcpuid 0.4.0 and brethen conflict with libcpuid 0.3.0 and its
brethen