### PR TITLE
Dump MSRs value

### DIFF
--- a/cpuid_tool/cpuid_tool.c
+++ b/cpuid_tool/cpuid_tool.c
@@ -89,6 +89,7 @@ typedef enum {
 	NEED_CLOCK_RDTSC,
 	NEED_CLOCK_IC,
 	NEED_RDMSR,
+	NEED_RDMSR_RAW,
 	NEED_SSE_UNIT_SIZE,
 } output_data_switch;
 
@@ -146,6 +147,7 @@ matchtable[] = {
 	{ NEED_CLOCK_RDTSC  , "--clock-rdtsc"  , 1},
 	{ NEED_CLOCK_IC     , "--clock-ic"     , 1},
 	{ NEED_RDMSR        , "--rdmsr"        , 0},
+	{ NEED_RDMSR_RAW    , "--rdmsr-raw"    , 0},
 	{ NEED_SSE_UNIT_SIZE, "--sse-size"     , 1},
 };
 
@@ -456,6 +458,16 @@ static void print_info(output_data_switch query, struct cpu_raw_data_t* raw,
 					fprintf(fout, "  core volt. : %.2lf Volts\n", value / 100.0);
 				if ((value = cpu_msrinfo(handle, INFO_BCLK)) != CPU_INVALID_VALUE)
 					fprintf(fout, "  base clock : %.2lf MHz\n", value / 100.0);
+				cpu_msr_driver_close(handle);
+			}
+			break;
+		}
+		case NEED_RDMSR_RAW:
+		{
+			if ((handle = cpu_msr_driver_open()) == NULL) {
+				fprintf(fout, "Cannot open MSR driver: %s\n", cpuid_error());
+			} else {
+				msr_serialize_raw_data(handle, "");
 				cpu_msr_driver_close(handle);
 			}
 			break;

--- a/libcpuid/exports.def
+++ b/libcpuid/exports.def
@@ -32,3 +32,4 @@ cpu_msr_driver_open_core @28
 cpuid_get_vendor @29
 cpu_rdmsr_range @30
 cpuid_get_epc @31
+msr_serialize_raw_data @32

--- a/libcpuid/libcpuid.h
+++ b/libcpuid/libcpuid.h
@@ -1105,6 +1105,25 @@ int cpu_msrinfo(struct msr_driver_t* handle, cpu_msrinfo_request_t which);
 #define CPU_INVALID_VALUE 0x3fffffff
 
 /**
+ * @brief Writes the raw MSR data to a text file
+ * @param data - a pointer to msr_driver_t structure
+ * @param filename - the path of the file, where the serialized data should be
+ *                   written. If empty, stdout will be used.
+ * @note This is intended primarily for debugging. On some processor, which is
+ *       not currently supported or not completely recognized by cpu_identify,
+ *       one can still successfully get the raw data and write it to a file.
+ *       libcpuid developers can later import this file and debug the detection
+ *       code as if running on the actual hardware.
+ *       The file is simple text format of "something=value" pairs. Version info
+ *       is also written, but the format is not intended to be neither backward-
+ *       nor forward compatible.
+ * @returns zero if successful, and some negative number on error.
+ *          The error message can be obtained by calling \ref cpuid_error.
+ *          @see cpu_error_t
+ */
+int msr_serialize_raw_data(struct msr_driver_t* handle, const char* filename);
+
+/**
  * @brief Closes an open MSR driver
  *
  * This function unloads the MSR driver opened by cpu_msr_driver_open and

--- a/libcpuid/libcpuid.sym
+++ b/libcpuid/libcpuid.sym
@@ -29,3 +29,4 @@ cpu_msr_driver_open_core
 cpuid_get_vendor
 cpu_rdmsr_range
 cpuid_get_epc
+msr_serialize_raw_data


### PR DESCRIPTION
Hi @anrieff,

It is hard to me to debug wrong values returned by `cpu_msrinfo()` without some informations.
For instance, [this comment](https://github.com/X0rg/CPU-X/issues/47#issuecomment-256488305) shows a base clock of 87,80MHz instead of ~100MHz.

I hope I can fix that by looking MSRs value, and to perform this operation, I have added a `msr_serialize_raw_data()`function.
This function works like `cpuid_serialize_raw_data()`.

Here is an example:
```
# cpuid_tool --rdmsr-raw                  
CPU is GenuineIntel Intel(R) Core(TM) i5-2500K CPU @ 3.30GHz, stock clock is 3300MHz.
msr[0x0000e7]=00 00 02 f7 03 bb cc cf 
msr[0x0000e8]=00 00 01 ef 94 bb 83 19 
msr[0x000198]=00 00 25 f3 00 00 20 00 
msr[0x00019c]=00 00 00 00 88 40 00 00 
msr[0x00002a]=00 00 00 00 00 00 00 00 
msr[0x0001ad]=00 00 00 00 26 27 28 2a 
msr[0x0001a2]=00 00 00 00 00 62 12 00 
msr[0x000198]=00 00 26 6e 00 00 22 00 
msr[0x0000ce]=00 00 10 00 70 01 21 00
```

I plan to use this RAW dump for debugging purpose only, that is why this function is only called with `--rdmsr-raw` argument.