### PR TITLE
Various changes for RDMSR

### DIFF
--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -913,8 +913,10 @@ int cpu_msrinfo(struct msr_driver_t* handle, cpu_msrinfo_request_t which)
 	static struct internal_id_info_t internal;
 	static struct msr_info_t info;
 
-	if (handle == NULL)
-		return set_error(ERR_HANDLE);
+	if (handle == NULL) {
+		set_error(ERR_HANDLE);
+		return CPU_INVALID_VALUE;
+	}
 
 	if (!init) {
 		err  = cpuid_get_raw_data(&raw);


### PR DESCRIPTION
Hi @anrieff,

Following #82, here are my changes: the main commit is d5c892e, others are more cosmetics.
Thanks to @TotalCaesar659, I have fixed the `cpu_msrinfo()` for AMD CPUs: both `INFO_MIN_MULTIPLIER` and `INFO_BUS_CLOCK` were wrongs.

I think I need to justify some of these changes, so let me explain.
- On his Phenom II X4 945 (**10h** family), minimum on maximum multipliers are [8:30] instead of [4:15], resulting of an incorrect bus clock.
The maximum multiplier is computed by reading P-state 0:
```
 msr[0xc0010064]=80 00 01 bb 3c 00 30 0e
```
CpuDid is [8:6]=0 and CpuFid is [5:0]=14.
AMD gives the following formula: `(100 MHz * (CpuFid + 10h) / (2^CpuDid))`
The result is 3000, and that's the CPU clock. But the maximum multiplier itself cannot be computed as is, that's why I use `((CpuFid + 10h) / (2^CpuDid)) / 2`: the result is 15, that's good.
So, the new bus clock computed is 3000/15=200MHz. 🍺 

* On his A8-7410 APU (**16h** family), only the maximum multiplier is correct. Minimum multiplier and bus clock are wrongs, there are respectively x16 and 87,70MHz instead of x10 and 100MHz.
The minimum multiplier is wrong to due incorrect P-state looked:
```
 msr[0xc0010061]=00 00 00 00 00 00 00 50
```
PstateMaxVal is [6:4]=5, but on this CPU, there are 8 P-state, that's why we cannot use PstateMaxVal to determine minimum multiplier.
With this patch, ths minimum multiplier should be read from last P-state:
```
msr[0xc001006b]=80 00 02 84 00 40 e0 44
```
CpuDid is [8:6]=1 and CpuFid is [5:0]=4. `(4 + 0x10) / 2¹` = 10, this is expected value.

The last change is about bus clock: CurPstateLimit is 0, so P-state 0 is used, but that's wrong.
`NumBoostStates + PstateMaxVal` is the total count of P-state, and the first non-boosted P-state is needed to determine bus clock.
But, unfortunaly, I can't retrieve NumBoostStates (it's a PCI address, D18F4x15C), that's why I do a tricky patch (eac52e7).
I think `LAST_PSTATE - MSR_PSTATE_0 - PstateMaxVal` is a valid formula to find the first non-boosted P-state: in this case, this is `0xC001006B - 0xC0010064 - 5` = 2, corresponding to:
```
msr[0xc0010066]=80 00 01 28 00 00 6c 06
```
CpuDid is [8:6]=0 and CpuFid is [5:0]=6. `(6 + 0x10) / 2⁰` = 22, and that's what we want.

Sorry for long text, but it was required to help me to find last minute bug.
This is very theorical, these changes are untested, but thanks to mathematics, I'm sure it will fix these issues for these CPUs.