### PR TITLE
Fixes for #84

### DIFF
--- a/cpuid_tool/cpuid_tool.c
+++ b/cpuid_tool/cpuid_tool.c
@@ -446,18 +446,20 @@ static void print_info(output_data_switch query, struct cpu_raw_data_t* raw,
 					fprintf(fout, "  MSR.mperf  : %d MHz\n", value);
 				if ((value = cpu_msrinfo(handle, INFO_APERF)) != CPU_INVALID_VALUE)
 					fprintf(fout, "  MSR.aperf  : %d MHz\n", value);
+				if ((value = cpu_msrinfo(handle, INFO_MIN_MULTIPLIER)) != CPU_INVALID_VALUE)
+					fprintf(fout, "  min. multi.: %d\n", value / 100.0);
 				if ((value = cpu_msrinfo(handle, INFO_CUR_MULTIPLIER)) != CPU_INVALID_VALUE)
-					fprintf(fout, "  cur. multi.: %d MHz\n", value);
+					fprintf(fout, "  cur. multi.: %d\n", value / 100.0);
 				if ((value = cpu_msrinfo(handle, INFO_MAX_MULTIPLIER)) != CPU_INVALID_VALUE)
-					fprintf(fout, "  max. multi.: %d MHz\n", value);
+					fprintf(fout, "  max. multi.: %d\n", value / 100.0);
 				if ((value = cpu_msrinfo(handle, INFO_TEMPERATURE)) != CPU_INVALID_VALUE)
 					fprintf(fout, "  temperature: %d degrees Celsius\n", value);
 				if ((value = cpu_msrinfo(handle, INFO_THROTTLING)) != CPU_INVALID_VALUE)
 					fprintf(fout, "  throttling : %s\n", value ? "yes" : "no");
 				if ((value = cpu_msrinfo(handle, INFO_VOLTAGE)) != CPU_INVALID_VALUE)
 					fprintf(fout, "  core volt. : %.2lf Volts\n", value / 100.0);
-				if ((value = cpu_msrinfo(handle, INFO_BCLK)) != CPU_INVALID_VALUE)
-					fprintf(fout, "  base clock : %.2lf MHz\n", value / 100.0);
+				if ((value = cpu_msrinfo(handle, INFO_BUS_CLOCK)) != CPU_INVALID_VALUE)
+					fprintf(fout, "  bus clock  : %.2lf MHz\n", value / 100.0);
 				cpu_msr_driver_close(handle);
 			}
 			break;


### PR DESCRIPTION
1. The first commit (6ae7e34) is a minor fix with for `cpuid_tool --rdmsr` command.

Before change:
```
  MSR.mperf  : 2224 MHz
  MSR.aperf  : 2049 MHz
  cur. multi.: 3500 MHz
  max. multi.: 4500 MHz
  temperature: 35 degrees Celsius
  core volt. : 1.20 Volts
  base clock : 100.00 MHz
```
After change:
```
  MSR.mperf  : 28 MHz
  MSR.aperf  : 387 MHz
  min. mult. : 16
  cur. mult. : 43
  max. mult. : 45
  temperature: 33 degrees Celsius
  core volt. : 1.41 Volts
  bus clock  : 100.00 MHz
```

2. The second commit (e5193b0) fix #84.

The `get_amd_last_pstate_addr()` function solve issues with minimum CPU multiplier and bus clock (for AMD CPUs), thank to the **PstateEn** bit.

Calculated for Phenom II X4 940, Phenom II X4 945 and A8-7410 CPUs, theoretical results are good.