### PR TITLE
Fixes for #91

### DIFF
--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -889,13 +889,14 @@ static double get_info_voltage(struct msr_info_t *info)
 		MSRC001_00[6B:64][21:14] is CpuVid (Zen)
 		MSRC001_0063[2:0] is P-state Status
 		BKDG 10h, page 49: voltage = 1.550V - 0.0125V * SviVid (SVI1)
-		BKDG 15h, page 50: Voltage = 1.5500 - 0.00625 * Vid[7:0] (SVI2) */
+		BKDG 15h, page 50: Voltage = 1.5500 - 0.00625 * Vid[7:0] (SVI2)
+		SVI2 since Piledriver (Family 15h, 2nd-gen): Models 10h-1Fh Processors */
+		VIDStep = ((info->id->ext_family < 0x15) || ((info->id->ext_family == 0x15) && (info->id->ext_model < 0x10))) ? 0.0125 : 0.00625;
 		err = cpu_rdmsr_range(info->handle, MSR_PSTATE_S, 2, 0, &reg);
 		if(info->id->ext_family < 0x17)
 			err += cpu_rdmsr_range(info->handle, MSR_PSTATE_0 + (uint32_t) reg, 15, 9, &CpuVid);
 		else
 			err += cpu_rdmsr_range(info->handle, MSR_PSTATE_0 + (uint32_t) reg, 21, 14, &CpuVid);
-		VIDStep = (info->id->ext_family < 0x15) ? 0.0125 : 0.00625;
 		if (!err && MSR_PSTATE_0 + (uint32_t) reg <= MSR_PSTATE_7) return 1.550 - VIDStep * CpuVid;
 	}
 

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -640,7 +640,8 @@ static int get_amd_multipliers(struct msr_info_t *info, uint32_t pstate, double 
 
 	/* Constant values for common families */
 	const int magic_constant = (info->id->ext_family == 0x11) ? 0x8 : 0x10;
-	const double divisor = ((FUSION_C <= info->internal->code.amd) && (info->internal->code.amd <= FUSION_A)) ? 1.0 : 2.0;
+	const int is_apu = ((FUSION_C <= info->internal->code.amd) && (info->internal->code.amd <= FUSION_A)) || (info->internal->bits & _APU_);
+	const double divisor = is_apu ? 1.0 : 2.0;
 
 	/* Check if P-state is valid */
 	if (pstate < MSR_PSTATE_0 || MSR_PSTATE_7 < pstate)


### PR DESCRIPTION
Changes in 58b8eab are explained in #91.

Changes in 84f95c8 should fix the wrong voltage. But, according to AMD's BKDG, the SVI2 is used since 10h models in 15h family, and FX-8320E is 2h model.
To be conformant to BKDG, this model should use 0.0125V VID steps (SVI1), but this patch will use 0.00625V VID steps for this model (SVI2), to fix your issue with FX-8320E.

Are you sure it is 1.36V? From where come this value?