### PR TITLE
Do not depend on config.h in public headers

### DIFF
--- a/libcpuid/libcpuid_types.h
+++ b/libcpuid/libcpuid_types.h
@@ -32,19 +32,15 @@
 #ifndef __LIBCPUID_TYPES_H__
 #define __LIBCPUID_TYPES_H__
 
-#ifdef HAVE_CONFIG_H
-#  include "config.h"
-#endif
-
-#if defined(HAVE_STDINT_H)
+#if !defined(_MSC_VER) || _MSC_VER >= 1600
 #  include <stdint.h>
 #else
 /* we have to provide our own: */
-#  if !defined(HAVE_INT32_T) && !defined(__int32_t_defined)
+#  if !defined(__int32_t_defined)
 typedef int int32_t;
 #  endif
 
-#  if !defined(HAVE_UINT32_T) && !defined(__uint32_t_defined)
+#  if !defined(__uint32_t_defined)
 typedef unsigned uint32_t;
 #  endif
 


### PR DESCRIPTION
`config.h` is not installed with libcpuid, and even if it were `HAVE_CONFIG_H` could
not be used to check for its availability.

Closes #102.

For the reference, see https://github.com/conda/conda-build/wiki/Windows-recipe-patterns#duplicate-stdinth-symbols , https://github.com/libarchive/libarchive/blob/v3.3.2/libarchive/archive.h#L47