### PR TITLE
Update CPUs database

### DIFF
--- a/libcpuid/recog_amd.c
+++ b/libcpuid/recog_amd.c
@@ -50,9 +50,12 @@ enum _amd_model_codes_t {
 	_1500,
 	_1600,
 	_1900,
+	_2200,
 	_2400,
 	_2500,
+	_2600,
 	_2700,
+	_2800,
 };
 
 
@@ -283,11 +286,14 @@ const struct match_entry_t cpudb_amd[] = {
 	{ 15, -1, -1, 23,    1,   4,    -1,    -1, NC, 0                   , _1400, "Ryzen 5 (Summit Ridge)"        },
 	{ 15, -1, -1, 23,    1,   4,    -1,    -1, NC, 0                   ,     0, "Ryzen 3 (Summit Ridge)"        },
 	/* APUs */
+	{ 15, -1, -1, 23,   17,   4,    -1,    -1, NC, 0                   , _2800, "Ryzen 7 (Raven Ridge)"         },
 	{ 15, -1, -1, 23,   17,   4,    -1,    -1, NC, 0                   , _2700, "Ryzen 7 (Raven Ridge)"         },
+	{ 15, -1, -1, 23,   17,   4,    -1,    -1, NC, 0                   , _2600, "Ryzen 5 (Raven Ridge)"         },
 	{ 15, -1, -1, 23,   17,   4,    -1,    -1, NC, 0                   , _2500, "Ryzen 5 (Raven Ridge)"         },
 	{ 15, -1, -1, 23,   17,   4,    -1,    -1, NC, 0                   , _2400, "Ryzen 5 (Raven Ridge)"         },
 	{ 15, -1, -1, 23,   17,   4,    -1,    -1, NC, 0                   ,     0, "Ryzen 3 (Raven Ridge)"         },
-	{ 15, -1, -1, 23,   17,   2,    -1,    -1, NC, 0                   ,     0, "Ryzen 3 (Raven Ridge)"         },
+	{ 15, -1, -1, 23,   17,   2,    -1,    -1, NC, 0                   , _2200, "Ryzen 3 (Raven Ridge)"         },
+	{ 15, -1, -1, 23,   17,   2,    -1,    -1, NC, 0                   ,     0, "Athlon (Raven Ridge)"          },
 	/* 2nd-gen, Zen+ (2018): */
 	{ 15, -1, -1, 23,    8,   8,    -1,    -1, NC, 0                   ,     0, "Ryzen 7 (Pinnacle Ridge)"      },
 	{ 15, -1, -1, 23,    8,   6,    -1,    -1, NC, 0                   ,     0, "Ryzen 5 (Pinnacle Ridge)"      },

--- a/libcpuid/recog_amd.c
+++ b/libcpuid/recog_amd.c
@@ -495,9 +495,12 @@ static int decode_amd_ryzen_model_code(const char* bs)
 		int model_code;
 		const char* match_str;
 	} patterns[] = {
+		{ _2800, "2800" },
 		{ _2700, "2700" },
+		{ _2600, "2600" },
 		{ _2500, "2500" },
 		{ _2400, "2400" },
+		{ _2200, "2200" },
 		{ _1900, "1900" },
 		{ _1600, "1600" },
 		{ _1500, "1500" },

--- a/libcpuid/recog_amd.c
+++ b/libcpuid/recog_amd.c
@@ -297,6 +297,8 @@ const struct match_entry_t cpudb_amd[] = {
 	/* 2nd-gen, Zen+ (2018): */
 	{ 15, -1, -1, 23,    8,   8,    -1,    -1, NC, 0                   ,     0, "Ryzen 7 (Pinnacle Ridge)"      },
 	{ 15, -1, -1, 23,    8,   6,    -1,    -1, NC, 0                   ,     0, "Ryzen 5 (Pinnacle Ridge)"      },
+	{ 15, -1, -1, 23,    8,   4,    -1,    -1, NC, 0                   , _2500, "Ryzen 5 (Pinnacle Ridge)"      },
+	{ 15, -1, -1, 23,    8,   4,    -1,    -1, NC, 0                   ,     0, "Ryzen 3 (Pinnacle Ridge)"      },
 
 
 	/* Newer Opterons: */

--- a/libcpuid/recog_amd.c
+++ b/libcpuid/recog_amd.c
@@ -295,6 +295,10 @@ const struct match_entry_t cpudb_amd[] = {
 	{ 15, -1, -1, 23,   17,   2,    -1,    -1, NC, 0                   , _2200, "Ryzen 3 (Raven Ridge)"         },
 	{ 15, -1, -1, 23,   17,   2,    -1,    -1, NC, 0                   ,     0, "Athlon (Raven Ridge)"          },
 	/* 2nd-gen, Zen+ (2018): */
+	{ 15, -1, -1, 23,    8,  32,    -1,    -1, NC, 0                   ,     0, "Threadripper (Colfax)"         },
+	{ 15, -1, -1, 23,    8,  24,    -1,    -1, NC, 0                   ,     0, "Threadripper (Colfax)"         },
+	{ 15, -1, -1, 23,    8,  16,    -1,    -1, NC, 0                   ,     0, "Threadripper (Colfax)"         },
+	{ 15, -1, -1, 23,    8,  12,    -1,    -1, NC, 0                   ,     0, "Threadripper (Colfax)"         },
 	{ 15, -1, -1, 23,    8,   8,    -1,    -1, NC, 0                   ,     0, "Ryzen 7 (Pinnacle Ridge)"      },
 	{ 15, -1, -1, 23,    8,   6,    -1,    -1, NC, 0                   ,     0, "Ryzen 5 (Pinnacle Ridge)"      },
 	{ 15, -1, -1, 23,    8,   4,    -1,    -1, NC, 0                   , _2500, "Ryzen 5 (Pinnacle Ridge)"      },

--- a/libcpuid/recog_amd.c
+++ b/libcpuid/recog_amd.c
@@ -277,9 +277,9 @@ const struct match_entry_t cpudb_amd[] = {
 	{ 15,  0, -1, 22,   48,   4,    -1,    -1, FUSION_A, 0             ,     0, "Mullins X4"                    },
 
 	/* Family 17h: Zen Architecture (2017) */
-	{ 15, -1, -1, 23,    1,  16,    -1,    -1, NC, 0                   ,     0, "Threadripper (Summit Ridge)"   },
-	{ 15, -1, -1, 23,    1,  12,    -1,    -1, NC, 0                   ,     0, "Threadripper (Summit Ridge)"   },
-	{ 15, -1, -1, 23,    1,   8,    -1,    -1, NC, 0                   , _1900, "Threadripper (Summit Ridge)"   },
+	{ 15, -1, -1, 23,    1,  16,    -1,    -1, NC, 0                   ,     0, "Threadripper (Whitehaven)"     },
+	{ 15, -1, -1, 23,    1,  12,    -1,    -1, NC, 0                   ,     0, "Threadripper (Whitehaven)"     },
+	{ 15, -1, -1, 23,    1,   8,    -1,    -1, NC, 0                   , _1900, "Threadripper (Whitehaven)"     },
 	{ 15, -1, -1, 23,    1,   8,    -1,    -1, NC, 0                   ,     0, "Ryzen 7 (Summit Ridge)"        },
 	{ 15, -1, -1, 23,    1,   6,    -1,    -1, NC, 0                   , _1600, "Ryzen 5 (Summit Ridge)"        },
 	{ 15, -1, -1, 23,    1,   4,    -1,    -1, NC, 0                   , _1500, "Ryzen 5 (Summit Ridge)"        },

--- a/libcpuid/recog_intel.c
+++ b/libcpuid/recog_intel.c
@@ -348,11 +348,15 @@ const struct match_entry_t cpudb_intel[] = {
 	{  6, 14, -1, -1, 142,  2,    -1,    -1, NC, CELERON_      ,     0, "Kaby Lake-U (Celeron)"    },
 	{  6, 14, -1, -1, 142,  2,    -1,    -1, NC, CORE_|_M_|_3  ,     0, "Kaby Lake-U (Core m3)"    },
 
-
 	/* Coffee Lake CPUs (14nm): */
+	{  6, 14, -1, -1, 158,  8,    -1,    -1, NC, CORE_|_I_|_9  ,     0, "Coffee Lake (Core i9)"    },
+	{  6, 14, -1, -1, 158,  8,    -1,    -1, NC, CORE_|_I_|_7  ,     0, "Coffee Lake (Core i7)"    },
 	{  6, 14, -1, -1, 158,  6,    -1,    -1, NC, CORE_|_I_|_7  ,     0, "Coffee Lake (Core i7)"    },
 	{  6, 14, -1, -1, 158,  6,    -1,    -1, NC, CORE_|_I_|_5  ,     0, "Coffee Lake (Core i5)"    },
 	{  6, 14, -1, -1, 158,  4,    -1,    -1, NC, CORE_|_I_|_3  ,     0, "Coffee Lake (Core i3)"    },
+	{  6, 14, -1, -1, 158,  2,    -1,    -1, NC, PENTIUM_      ,     0, "Coffee Lake (Pentium)"    },
+	{  6, 14, -1, -1, 158,  2,    -1,    -1, NC, CELERON_      ,     0, "Coffee Lake (Celeron)"    },
+
 
 	/* Itaniums */
 	{  7, -1, -1, -1, -1,   1,    -1,    -1, NC, 0             ,     0, "Itanium"                  },


### PR DESCRIPTION
Hello,

Some new processors, both on AMD and Intel side.
No new test are available, but no regression in existing tests.

:question: 
According to WikiChip, [EPYC CPUs (codename Naples)](https://en.wikichip.org/wiki/amd/cores/naples) are not (yet) recognized.
Wouldn't it better to detect Zen CPUs by using `model_bits` field instead of `model_code` field, like Intel's Core CPUs?
I'm not sure about `_amd_model_codes_t` purpose. It can introduce mistakes (like ee32a4a7357083e7e9e47bd3ef52937f5d984453).