### PR TITLE
Add support for get_total_cpus on Haiku.

### DIFF
--- a/libcpuid/cpuid_main.c
+++ b/libcpuid/cpuid_main.c
@@ -114,6 +114,17 @@ static int get_total_cpus(void)
 #define GET_TOTAL_CPUS_DEFINED
 #endif
 
+#ifdef __HAIKU__
+#include <OS.h>
+static int get_total_cpus(void)
+{
+	system_info info;
+	get_system_info(&info);
+	return info.cpu_count;
+}
+#define GET_TOTAL_CPUS_DEFINED
+#endif
+
 #if defined linux || defined __linux__ || defined __sun
 #include <sys/sysinfo.h>
 #include <unistd.h>


### PR DESCRIPTION
This adds an implementation of get_total_cpus() for the Haiku operating system (open source BeOS compatible OS).