### PR TITLE
Fix compilation on non-x86/ARM architectures.

### DIFF
--- a/libcpuid/asm-bits.c
+++ b/libcpuid/asm-bits.c
@@ -70,8 +70,6 @@ int cpuid_exists_by_eflags(void)
 #  else
 	return 0;
 #  endif /* COMPILER_MICROSOFT */
-#elif defined(PLATFORM_ARM)
-  return 0;
 #else
 	return 0;
 #endif /* PLATFORM_X86 */
@@ -137,7 +135,6 @@ void exec_cpuid(uint32_t *regs)
 		:"m"(regs)
 		:"memory", "eax", "edi"
 	);
-#	elif defined(PLATFORM_ARM)
 #	endif /* COMPILER_GCC */
 #else
 #  ifdef COMPILER_MICROSOFT
@@ -177,20 +174,17 @@ void cpu_rdtsc(uint64_t* result)
 {
 	uint32_t low_part, hi_part;
 #if defined(COMPILER_GCC) || defined(COMPILER_CLANG)
-#ifdef PLATFORM_ARM
-  low_part = 0;
-  hi_part = 0;
-#elif defined(PLATFORM_AARCH64)
-  low_part = 0;
-  hi_part = 0;
-#else
+#  if defined(PLATFORM_X86) || defined(PLATFORM_X64)
 	__asm __volatile (
 		"	rdtsc\n"
 		"	mov	%%eax,	%0\n"
 		"	mov	%%edx,	%1\n"
 		:"=m"(low_part), "=m"(hi_part)::"memory", "eax", "edx"
 	);
-#endif
+#  else
+  low_part = 0;
+  hi_part = 0;
+#  endif
 #else
 #  ifdef COMPILER_MICROSOFT
 	__asm {
@@ -215,9 +209,7 @@ void busy_sse_loop(int cycles)
 #else
 #	define XALIGN ".align 4\n"
 #endif
-#ifdef PLATFORM_ARM
-#elif defined(PLATFORM_AARCH64)
-#else
+#if defined(PLATFORM_X86) || defined(PLATFORM_X64)
 	__asm __volatile (
 		"	xorps	%%xmm0,	%%xmm0\n"
 		"	xorps	%%xmm1,	%%xmm1\n"

--- a/libcpuid/asm-bits.h
+++ b/libcpuid/asm-bits.h
@@ -62,9 +62,8 @@
 #endif
 
 /* Under Windows/AMD64 with MSVC, inline assembly isn't supported */
-#if (((defined(COMPILER_GCC) || defined(COMPILER_CLANG))) &&  \
-     (defined(PLATFORM_X64) || defined(PLATFORM_X86) || defined(PLATFORM_ARM) || defined(PLATFORM_AARCH64))) || \
-	 (defined(COMPILER_MICROSOFT) && defined(PLATFORM_X86))
+#if (defined(COMPILER_GCC) || defined(COMPILER_CLANG)) || \
+	(defined(COMPILER_MICROSOFT) && defined(PLATFORM_X86))
 #	define INLINE_ASM_SUPPORTED
 #endif
 


### PR DESCRIPTION
This replaces the dummy ARM checks in asm-bits.c with generic `else` paths to allow compilation on any non-x86(-64) architecture, not just ARM.

I'm using this to build libcpuid on PPC (MacOS X 10.5), PPC64EL and S390X (both Linux via Snapcraft).
