### PR TITLE
Add CMake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.14)
+
+set(VERSION "0.4.1")
+project(cpuid LANGUAGES C CXX ASM VERSION ${VERSION})
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_C_STANDARD 11)
+
+add_subdirectory(libcpuid)
+add_subdirectory(cpuid_tool)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.14)
 set(VERSION "0.4.1")
 project(cpuid LANGUAGES C CXX ASM VERSION ${VERSION})
 
-set(CMAKE_CXX_STANDARD 20)
-set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_C_STANDARD 99)
 
 add_subdirectory(libcpuid)
 add_subdirectory(cpuid_tool)

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/cpuid_tool/CMakeLists.txt
+++ b/cpuid_tool/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_executable(cpuid_tool cpuid_tool.c)
+target_link_libraries(cpuid_tool PRIVATE cpuid)
+
+install(TARGETS cpuid_tool
+        CONFIGURATIONS Debug
+        RUNTIME DESTINATION bin/Debug)
+install(TARGETS cpuid_tool
+        CONFIGURATIONS Release
+        RUNTIME DESTINATION bin/Release)

--- a/libcpuid/CMakeLists.txt
+++ b/libcpuid/CMakeLists.txt
@@ -1,0 +1,80 @@
+add_library(cpuid
+            cpuid_main.c
+            recog_intel.c
+            recog_amd.c
+            rdtsc.c
+            asm-bits.c
+            libcpuid_util.c
+            rdmsr.c
+            msrdriver.c
+            )
+target_include_directories(cpuid SYSTEM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
+
+target_compile_definitions(cpuid PRIVATE VERSION="${PROJECT_VERSION}")
+set(CPUID_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/libcpuid.h ${CMAKE_CURRENT_SOURCE_DIR}/libcpuid_constants.h ${CMAKE_CURRENT_SOURCE_DIR}/libcpuid_types.h)
+set_target_properties(cpuid PROPERTIES
+                      PUBLIC_HEADER "${CPUID_HEADERS}"
+                      )
+
+#Documentation
+find_package(Doxygen)
+option(ENABLE_DOCS "Enable building documentation." ON)
+if (DOXYGEN_FOUND AND ENABLE_DOCS)
+    set(top_srcdir ${PROJECT_SOURCE_DIR})
+    configure_file(Doxyfile.in
+                   Doxyfile
+                   ESCAPE_QUOTES
+                   )
+    add_custom_target(docs
+                      ALL
+                      ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
+                      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/
+                      COMMENT "Generating API documentation with Doxygen" VERBATIM
+                      )
+else ()
+    add_custom_target(docs
+                      echo "Doxygen was not installed when CMake was run or ENABLE_DOCS was OFF. Check that Doxygen is installed and rerun `cmake .`" VERBATIM
+                      )
+endif ()
+
+#Configuration
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+set(config_install_dir "lib/cmake/${PROJECT_NAME}")
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(TARGETS_EXPORT_NAME "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Use:
+#   * PROJECT_VERSION
+write_basic_package_version_file(
+        "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+        "${CMAKE_SOURCE_DIR}/cmake/Config.cmake.in"
+        "${project_config}"
+        INSTALL_DESTINATION "${config_install_dir}"
+)
+#Installation
+install(TARGETS cpuid
+        EXPORT "${TARGETS_EXPORT_NAME}"
+        LIBRARY DESTINATION "lib"
+        ARCHIVE DESTINATION "lib"
+        RUNTIME DESTINATION "bin"
+        INCLUDES DESTINATION "include")
+
+install(FILES "${project_config}" "${version_config}"
+        DESTINATION "${config_install_dir}"
+        )
+install(EXPORT "${TARGETS_EXPORT_NAME}"
+        NAMESPACE "${namespace}"
+        DESTINATION "${config_install_dir}"
+        )


### PR DESCRIPTION
Add support for cmake build system.
Why?
Works on all platforms/architectures.
No need to get stuck with ancient VS sln files
Generates stuff for later consuming the output library in your projects (cpuidConfig.cmake stuff)

Actually, I need `libcpuid` as `vcpkg` and it will be a lot easier to create vcpkg port if the build system is cmake, thats why :)