### PR TITLE
cmake: fix installation of BUNDLE if iOS

### DIFF
--- a/cpuid_tool/CMakeLists.txt
+++ b/cpuid_tool/CMakeLists.txt
@@ -12,5 +12,5 @@ if(WIN32)
     CONFIGURATIONS Release
     RUNTIME DESTINATION bin/Release)
 else()
-  install(TARGETS cpuid_tool RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+  install(TARGETS cpuid_tool DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()


### PR DESCRIPTION
If host is iOS, CMake configuration fails, because on iOS executables are BUNDLE by default, not RUNTIME, and they need a DESTINATION in install() command.
see https://cmake.org/cmake/help/latest/policy/CMP0006.html