### PR TITLE
cmake: allow libcpuid to be added as a CMake subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD 99)
 
 # Global variables
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 if(UNIX)
   include(GNUInstallDirs)

--- a/libcpuid/CMakeLists.txt
+++ b/libcpuid/CMakeLists.txt
@@ -67,7 +67,7 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file("${version_config}" COMPATIBILITY SameMajorVersion)
 
 # Configure '<PROJECT-NAME>Config.cmake' Use variables: * TARGETS_EXPORT_NAME * PROJECT_NAME
-configure_package_config_file("${CMAKE_MODULE_PATH}/Config.cmake.in" "${project_config}"
+configure_package_config_file("${PROJECT_SOURCE_DIR}/cmake/Config.cmake.in" "${project_config}"
                               INSTALL_DESTINATION "${config_install_dir}")
 
 # Installation


### PR DESCRIPTION
CMAKE_SOURCE_DIR refers to top level CMakeLists folder, and libcpuid might not be the top level project if added through add_subdirectory() in an other project.

Moreover, it is bad practice to override `CMAKE_MODULE_PATH`, prefer to append new paths in this variable.