### PR TITLE
cmake: allow to build either static or shared

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,13 @@ project(
   LANGUAGES C CXX ASM_MASM
   VERSION ${VERSION})
 
+if(MSVC)
+  set(LIBCPUID_SHARED OFF)
+else()
+  set(LIBCPUID_SHARED ON)
+endif()
+option(BUILD_SHARED_LIBS "Build shared lib" ${LIBCPUID_SHARED})
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD 99)
 

--- a/libcpuid/CMakeLists.txt
+++ b/libcpuid/CMakeLists.txt
@@ -12,11 +12,8 @@ if("${MSVC_CXX_ARCHITECTURE_ID}" MATCHES "x64")
   list(APPEND cpuid_sources masm-x64.asm)
 endif()
 
-if(UNIX)
-  add_library(cpuid SHARED ${cpuid_sources})
-else()
-  add_library(cpuid ${cpuid_sources})
-endif()
+add_library(cpuid ${cpuid_sources})
+set_property(TARGET cpuid PROPERTY WINDOWS_EXPORT_ALL_SYMBOLS ON)
 target_include_directories(cpuid SYSTEM PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 
 target_compile_definitions(cpuid PRIVATE VERSION="${PROJECT_VERSION}")


### PR DESCRIPTION
Users may want to build static lib on Unix platforms.
Moreoever, shared can work with Visual Studio (it's not specific to Windows but to Visual Studio compiler) with `WINDOWS_EXPORT_ALL_SYMBOLS`. It's a dirty solution, but the proper one would require to add a macro in front of all public symbols.

Honestly I would have prefered to build static by default on all platforms, but I kept previous logic to build shared by default, except for Visual Studio.