### PR TITLE
Don't link with msrdriver.c on non-Windows platform.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -56,6 +56,17 @@ if test "x$GCC" = "xyes"; then
     AM_LDFLAGS="$AM_LDFLAGS -g -Wall"
 fi
 
+AC_CANONICAL_HOST
+
+build_windows=no
+
+case "${host_os}" in
+    cygwin*|mingw*)
+        build_windows=yes
+        ;;
+esac
+
+AM_CONDITIONAL([WINDOWS], [test "$build_windows" = "yes"])
 
 AC_SUBST(AM_CPPFLAGS)
 AC_SUBST(AM_LDFLAGS)

--- a/libcpuid/CMakeLists.txt
+++ b/libcpuid/CMakeLists.txt
@@ -5,8 +5,11 @@ set(cpuid_sources
     rdtsc.c
     libcpuid_util.c
     rdmsr.c
-    msrdriver.c
     asm-bits.c)
+
+if(WIN32)
+   list(APPEND cpuid_sources msrdriver.c)
+endif()
 
 if("${MSVC_CXX_ARCHITECTURE_ID}" MATCHES "x64")
   list(APPEND cpuid_sources masm-x64.asm)

--- a/libcpuid/Makefile.am
+++ b/libcpuid/Makefile.am
@@ -13,8 +13,11 @@ libcpuid_la_SOURCES =		\
 	rdtsc.c			\
 	asm-bits.c		\
 	libcpuid_util.c		\
-	rdmsr.c			\
-	msrdriver.c
+	rdmsr.c
+
+if WINDOWS
+libcpuid_la_SOURCES += msrdriver.c
+endif
 
 libcpuid_la_DEPENDENCIES = \
 	$(srcdir)/libcpuid.sym


### PR DESCRIPTION
This simplify the procedure of sanitizing unneeded blob in source.