### PR TITLE
Report memory allocation failures without segfaulting.

### DIFF
--- a/libcpuid/libcpuid.h
+++ b/libcpuid/libcpuid.h
@@ -1010,7 +1010,9 @@ struct cpu_list_t {
  * order of the parts.
  *
  * @param vendor the vendor to be queried
- * @param list [out] the resulting list will be written here.
+ * @param list [out] the resulting list will be written here. On failure,
+ * num_entries is set to zero and names to NULL. The error message can be
+ * obtained by calling \ref cpuid_error. @see cpu_error_t
  * NOTE: As the memory is dynamically allocated, be sure to call
  *       cpuid_free_cpu_list() after you're done with the data
  * @see cpu_list_t

--- a/libcpuid/libcpuid_util.c
+++ b/libcpuid/libcpuid_util.c
@@ -141,6 +141,11 @@ void generic_get_cpu_list(const struct match_entry_t* matchtable, int count,
 	int i, j, n, good;
 	n = 0;
 	list->names = (char**) malloc(sizeof(char*) * count);
+	if (!list->names) { /* Memory allocation failure */
+		set_error(ERR_NO_MEM);
+		list->num_entries = 0;
+		return;
+	}
 	for (i = 0; i < count; i++) {
 		if (strstr(matchtable[i].name, "Unknown")) continue;
 		good = 1;
@@ -151,10 +156,21 @@ void generic_get_cpu_list(const struct match_entry_t* matchtable, int count,
 			}
 		if (!good) continue;
 #if defined(_MSC_VER)
-		list->names[n++] = _strdup(matchtable[i].name);
+		list->names[n] = _strdup(matchtable[i].name);
 #else
-		list->names[n++] = strdup(matchtable[i].name);
+		list->names[n] = strdup(matchtable[i].name);
 #endif
+		if (!list->names[n]) { /* Memory allocation failure */
+			set_error(ERR_NO_MEM);
+			list->num_entries = 0;
+			for (j = 0; j < n; j++) {
+				free(list->names[j]);
+			}
+			free(list->names);
+			list->names = NULL;
+			return;
+		}
+		n++;
 	}
 	list->num_entries = n;
 }

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -92,6 +92,10 @@ struct msr_driver_t* cpu_msr_driver_open_core(unsigned core_num)
 		return NULL;
 	}
 	handle = (struct msr_driver_t*) malloc(sizeof(struct msr_driver_t));
+	if (!handle) {
+		set_error(ERR_NO_MEM);
+		return NULL;
+	}
 	handle->fd = fd;
 	return handle;
 }
@@ -176,6 +180,10 @@ struct msr_driver_t* cpu_msr_driver_open_core(unsigned core_num)
 		return NULL;
 	}
 	handle = (struct msr_driver_t*) malloc(sizeof(struct msr_driver_t));
+	if (!handle) {
+		set_error(ERR_NO_MEM);
+		return NULL;
+	}
 	handle->fd = fd;
 	return handle;
 }


### PR DESCRIPTION
Dereferencing `NULL` pointers in case of a memory allocation failure doesn't seem ideal, let's avoid that. `make test` succeeds. Unfortunately, I do not have a way of verifying whether the on-failure code actually works ...

Also (somewhat unrelated), the copyright lines at the top of the files do not seem up to date.