### PR TITLE
Allow user-defined LIBCPUID_SHARED to switch between building shared/static library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,14 @@ project(
   LANGUAGES C CXX ASM_MASM
   VERSION ${VERSION})
 
-if(MSVC)
-  set(LIBCPUID_SHARED OFF)
-else()
-  set(LIBCPUID_SHARED ON)
+if(NOT DEFINED LIBCPUID_SHARED)
+  if(MSVC)
+    set(LIBCPUID_SHARED OFF)
+  else()
+    set(LIBCPUID_SHARED ON)
+  endif()
 endif()
+
 option(BUILD_SHARED_LIBS "Build shared lib" ${LIBCPUID_SHARED})
 
 option(LIBCPUID_TESTS "Enable building tests" OFF)


### PR DESCRIPTION
My commit didn't change the default behavior, just use user-defined LIBCPUID_SHARED if defined.

And In fact, I'm wondering why build shared by default under Linux/GCC.
I guess libcpuid dependents on no any other library, so maybe build it as a static library always works?  
