### PR TITLE
Detect presence of hypervisor

### DIFF
--- a/libcpuid/exports.def
+++ b/libcpuid/exports.def
@@ -44,3 +44,4 @@ cpuid_free_raw_data_array @40
 affinity_mask_str @41
 cpuid_free_system_id @42
 affinity_mask_str_r @43
+cpuid_get_hypervisor @44

--- a/libcpuid/libcpuid.h
+++ b/libcpuid/libcpuid.h
@@ -149,6 +149,24 @@ typedef enum {
 #define NUM_CPU_PURPOSES NUM_CPU_PURPOSES
 
 /**
+ * @brief Hypervisor vendor, as guessed from the CPU_FEATURE_HYPERVISOR flag.
+ */
+typedef enum {
+	HYPERVISOR_NONE = 0,     /*!< no hypervisor */
+	HYPERVISOR_BHYVE,        /*!< FreeBSD bhyve hypervisor */
+	HYPERVISOR_HYPERV,       /*!< Microsoft Hyper-V or Windows Virtual PC hypervisor */
+	HYPERVISOR_KVM,          /*!< KVM hypervisor */
+	HYPERVISOR_PARALLELS,    /*!< Parallels hypervisor */
+	HYPERVISOR_QEMU,         /*!< QEMU hypervisor */
+	HYPERVISOR_VIRTUALBOX,   /*!< VirtualBox hypervisor */
+	HYPERVISOR_VMWARE,       /*!< VMware hypervisor */
+	HYPERVISOR_XEN,          /*!< Xen hypervisor */
+	NUM_HYPERVISOR_VENDORS,  /*!< Valid hypervisor vendor ids: 0..NUM_HYPERVISOR_VENDORS - 1 */
+	HYPERVISOR_UNKNOWN = -1,
+} hypervisor_vendor_t;
+#define NUM_HYPERVISOR_VENDORS NUM_HYPERVISOR_VENDORS
+
+/**
  * @brief Contains just the raw CPUID data.
  *
  * This contains only the most basic CPU data, required to do identification
@@ -591,6 +609,7 @@ typedef enum {
 	CPU_FEATURE_AVX512VNNI, /*!< AVX-512 Vector Neural Network Instructions */
 	CPU_FEATURE_AVX512VBMI, /*!< AVX-512 Vector Bit ManipulationInstructions (version 1) */
 	CPU_FEATURE_AVX512VBMI2, /*!< AVX-512 Vector Bit ManipulationInstructions (version 2) */
+	CPU_FEATURE_HYPERVISOR, /*!< Hypervisor present (always zero on physical CPUs) */
 	/* termination: */
 	NUM_CPU_FEATURES,
 } cpu_feature_t;
@@ -1166,6 +1185,24 @@ void cpuid_set_verbosiness_level(int level);
  *          @see cpu_vendor_t
  */
 cpu_vendor_t cpuid_get_vendor(void);
+
+/**
+ * @brief Obtains the hypervisor vendor from CPUID from the current CPU
+ * @param raw - Optional input - a pointer to the raw CPUID data, which is obtained
+ *              either by cpuid_get_raw_data or cpuid_deserialize_raw_data.
+ *              Can also be NULL, in which case the functions calls
+ *              cpuid_get_raw_data itself.
+ * @param data - Optional input - the decoded CPU features/info is written here.
+ *              Can also be NULL, in which case the functions calls
+ *              cpu_identify itself.
+ * @note If no hypervisor is detected, the hypervisor can be hidden in some cases.
+ *       Refer to https://github.com/anrieff/libcpuid/issues/90#issuecomment-296568713.
+ * @returns HYPERVISOR_UNKNOWN if failed,
+ *          HYPERVISOR_NONE if no hypervisor detected (or hidden),
+ *          otherwise the hypervisor vendor type.
+ *          @see hypervisor_vendor_t
+ */
+hypervisor_vendor_t cpuid_get_hypervisor(struct cpu_raw_data_t* raw, struct cpu_id_t* data);
 
 /**
  * @brief a structure that holds a list of processor names

--- a/libcpuid/libcpuid.sym
+++ b/libcpuid/libcpuid.sym
@@ -41,3 +41,4 @@ cpuid_free_raw_data_array
 affinity_mask_str
 cpuid_free_system_id
 affinity_mask_str_r
+cpuid_get_hypervisor


### PR DESCRIPTION
Here is a proposal for #90.
There is no need to store CPUID 0x40000000 in `struct cpu_raw_data_t` IMHO, as the goal is to check if the running host is a virtual machine or no.
Please review.