### PR TITLE
Query CPU info at least once even if set_cpu_affinity() fails

### DIFF
--- a/libcpuid/cpuid_main.c
+++ b/libcpuid/cpuid_main.c
@@ -1076,7 +1076,7 @@ int cpuid_get_all_raw_data(struct cpu_raw_data_array_t* data)
 	bool affinity_saved = save_cpu_affinity();
 
 	cpu_raw_data_array_t_constructor(data, true);
-	while (set_cpu_affinity(logical_cpu)) {
+	while (set_cpu_affinity(logical_cpu) || logical_cpu == 0) {
 		debugf(2, "Getting raw dump for logical CPU %i\n", logical_cpu);
 		cpuid_grow_raw_data_array(data, logical_cpu + 1);
 		raw_ptr = &data->raw[logical_cpu];


### PR DESCRIPTION
The current code returns successfully from `cpuid_get_all_raw_data()`, but doesn't actually query any CPU info if `set_cpu_affinity()` fails, e.g. because it is not implemented.

This patch makes sure `cpuid_get_raw_data()` is called at least once even if `set_cpu_affinity()` fails.