### PR TITLE
Fix build for NetBSD (and presumably DragonFly BSD)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,21 @@ fi
 
 AC_CANONICAL_HOST
 
+AC_MSG_CHECKING([Whether we need POSIX threads])
+AC_COMPILE_IFELSE([
+    AC_LANG_PROGRAM([
+        #if defined(__NetBSD__) || defined(__DragonFly__)
+        #else
+        #  error "no pthreads needed"
+        #endif
+    ])
+], [
+    AC_MSG_RESULT([yes])
+    AC_SUBST([LIBCPUID_LDFLAGS], ["-pthread"])
+], [
+    AC_MSG_RESULT([no])
+])
+
 build_windows=no
 
 case "${host_os}" in

--- a/libcpuid/Makefile.am
+++ b/libcpuid/Makefile.am
@@ -5,7 +5,8 @@ noinst_LTLIBRARIES =
 lib_LTLIBRARIES += libcpuid.la
 libcpuid_la_LDFLAGS = \
 	-export-symbols $(srcdir)/libcpuid.sym \
-	-no-undefined -version-info @LIBCPUID_VERSION_INFO@
+	-no-undefined -version-info @LIBCPUID_VERSION_INFO@ \
+	@LIBCPUID_LDFLAGS@
 libcpuid_la_SOURCES =		\
 	cpuid_main.c		\
 	recog_intel.c		\


### PR DESCRIPTION
These both use POSIX threads. I got a link error when cross-compiling using Nixpkgs (Linux -> NetBSD) that went away once I passed `-pthread`.

The autoconf is crafted to have the same conditional as the C code itself.