### PR TITLE
Various bug fixes

### DIFF
--- a/libcpuid/cpuid_main.c
+++ b/libcpuid/cpuid_main.c
@@ -1748,7 +1748,7 @@ hypervisor_vendor_t cpuid_get_hypervisor(struct cpu_raw_data_t* raw, struct cpu_
 	};
 
 	if (!data) {
-		if ((r = cpu_identify(raw, data)) < 0)
+		if ((r = cpu_identify(raw, &mydata)) < 0)
 			return HYPERVISOR_UNKNOWN;
 		data = &mydata;
 	}

--- a/libcpuid/rdmsr.c
+++ b/libcpuid/rdmsr.c
@@ -96,6 +96,7 @@ struct msr_driver_t* cpu_msr_driver_open_core(unsigned core_num)
 	handle = (struct msr_driver_t*) malloc(sizeof(struct msr_driver_t));
 	if (!handle) {
 		cpuid_set_error(ERR_NO_MEM);
+		close(fd);
 		return NULL;
 	}
 	handle->fd = fd;
@@ -1069,8 +1070,10 @@ int msr_serialize_raw_data(struct msr_driver_t* handle, const char* filename)
 
 	/* Get cached decoded CPUID information */
 	id = get_cached_cpuid();
-	if (id->vendor == VENDOR_UNKNOWN)
+	if (id->vendor == VENDOR_UNKNOWN) {
+		fclose(f);
 		return cpuid_get_error();
+	}
 
 	/* Get CPU stock speed */
 	if (cpu_clock == 0)
@@ -1082,7 +1085,7 @@ int msr_serialize_raw_data(struct msr_driver_t* handle, const char* filename)
 		case VENDOR_HYGON:
 		case VENDOR_AMD:   msr = amd_msr;   break;
 		case VENDOR_INTEL: msr = intel_msr; break;
-		default: return cpuid_set_error(ERR_CPU_UNKN);
+		default: fclose(f); return cpuid_set_error(ERR_CPU_UNKN);
 	}
 
 	/* Print raw MSR values */

--- a/libcpuid/recog_intel.c
+++ b/libcpuid/recog_intel.c
@@ -721,7 +721,7 @@ static int decode_intel_extended_topology(struct cpu_raw_data_t* raw, struct cpu
 {
 	int i, level_type, num_smt = -1, num_core = -1;
 
-	for (i = 0; (raw->intel_fn11[i][EAX] != 0x0) && (raw->intel_fn11[i][EBX] != 0x0) && (i < MAX_INTELFN11_LEVEL); i++) {
+	for (i = 0; (i < MAX_INTELFN11_LEVEL) && (raw->intel_fn11[i][EAX] != 0x0) && (raw->intel_fn11[i][EBX] != 0x0); i++) {
 		level_type = EXTRACTS_BITS(raw->intel_fn11[i][ECX], 15, 8);
 		switch (level_type) {
 			case 0x01:


### PR DESCRIPTION
This PR fixes various issues found by static analysis tools. The most serious issue is in `cpuid_get_hypervisor`, which leads to segmentation faults when the caller passes a NULL parameter, even though the documentation claims that it is safe.