### PR TITLE
Add missing call to cpuid_set_error

### DIFF
--- a/libcpuid/cpuid_main.c
+++ b/libcpuid/cpuid_main.c
@@ -1287,7 +1287,7 @@ int cpuid_get_raw_data_core(struct cpu_raw_data_t* data, logical_cpu_t logical_c
 	if (logical_cpu != (logical_cpu_t) -1) {
 		debugf(2, "Getting raw dump for logical CPU %u\n", logical_cpu);
 		if (!set_cpu_affinity(logical_cpu))
-			return ERR_INVCNB;
+			return cpuid_set_error(ERR_INVCNB);
 		affinity_saved = save_cpu_affinity();
 	}
 


### PR DESCRIPTION
Forgotten during c5d9b38.