### PR TITLE
Fix the test target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,7 @@ consistency:
 test: test-fast
 
 test-fast:
-	LD_PRELOAD=$(top_builddir)/libcpuid/.libs/libcpuid.so $(top_srcdir)/tests/run_tests.py $(top_builddir)/cpuid_tool/.libs/cpuid_tool --show-test-fast-warning $(top_srcdir)/tests
+	LD_PRELOAD=$(top_builddir)/libcpuid/.libs/libcpuid.so $(top_srcdir)/tests/run_tests.py --show-test-fast-warning $(top_builddir)/cpuid_tool/.libs/cpuid_tool $(top_srcdir)/tests
 
 test-old:
 	$(top_srcdir)/tests/run_tests.py $(top_builddir)/cpuid_tool/cpuid_tool $(top_srcdir)/tests


### PR DESCRIPTION
Without this change running `make test` results in

```
LD_PRELOAD=./libcpuid/.libs/libcpuid.so ./tests/run_tests.py ./cpuid_tool/.libs/cpuid_tool --show-test-fast-warning ./tests
usage: run_tests.py [-h] [--fix | --no-fix]
                    [--show-test-fast-warning | --no-show-test-fast-warning]
                    [cpuid_tool] input_test_files [input_test_files ...]
run_tests.py: error: argument cpuid_tool: ./build/cpuid_tool/cpuid_tool is not a file
```