### PR TITLE
python: do not require wheel for building

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "cffi", "wheel"]
+requires = ["setuptools", "cffi"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Setuptools 70.1+ does not need wheel at all; older versions would fetch wheel when building wheels (but not sdists).