### PR TITLE
CI: Exit on errors in illumos build.

### DIFF
--- a/.github/workflows/build_omnios.yml
+++ b/.github/workflows/build_omnios.yml
@@ -30,6 +30,8 @@ jobs:
         prepare: |
           pkg install developer/cmake developer/gcc13 runtime/python-312
         run: |
+          set -e
+          
           # Generate build system
           cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX="" -DLIBCPUID_ENABLE_TESTS=ON
 
@@ -38,7 +40,7 @@ jobs:
 
           # Run cpuid_tool
           ./build/cpuid_tool/cpuid_tool --save=- --all
-          pfexec ./build/cpuid_tool/cpuid_tool --rdmsr-raw --rdmsr
+          ./build/cpuid_tool/cpuid_tool --rdmsr-raw --rdmsr
 
           # Run tests
           make -C build consistency


### PR DESCRIPTION
Sorry, one quick fix I noticed while working on another, similar problem: we need to explicitly `set -e` in the script, else we'll silently ignore failures.